### PR TITLE
Initialization fix for bug in SimpleEWMA

### DIFF
--- a/ewma.go
+++ b/ewma.go
@@ -55,7 +55,8 @@ func NewMovingAverage(age ...float64) MovingAverage {
 type SimpleEWMA struct {
 	// The current value of the average. After adding with Add(), this is
 	// updated to reflect the average of all values seen thus far.
-	value float64
+	value       float64
+	initialized bool
 }
 
 // Value returns the current value of the moving average.
@@ -65,10 +66,11 @@ func (e *SimpleEWMA) Value() float64 {
 
 // Add adds a value to the series and updates the moving average.
 func (e *SimpleEWMA) Add(value float64) {
-	if e.value == 0 { // this is a proxy for "uninitialized"
-		e.value = value
-	} else {
+	if e.initialized {
 		e.value = (value * DECAY) + (e.value * (1 - DECAY))
+	} else {
+		e.value = value
+		e.initialized = true
 	}
 }
 

--- a/ewma_test.go
+++ b/ewma_test.go
@@ -17,6 +17,15 @@ var samples = [100]float64{
 	3197, 5139, 6101, 5279,
 }
 
+func TestInitialisation(t *testing.T) {
+	var e SimpleEWMA
+	e.Add(0)
+	e.Add(1)
+	if e.Value() != DECAY {
+		t.Errorf("e.Value() is %v, wanted %v", e.Value(), DECAY)
+	}
+}
+
 func TestSimpleEWMA(t *testing.T) {
 	var e SimpleEWMA
 	for _, f := range samples {


### PR DESCRIPTION
When the value reaches 0 after starting (trivially if the first values
are 0) the EWMA is deemed uninitialized, which leads to this:

Sequence : 0, 1
MA = 1

when what you really want is

Sequence : 0, 1
MA = alpha
