### PR TITLE
You lost slice[WARMUP_SAMPLES] item

### DIFF
--- a/ewma.go
+++ b/ewma.go
@@ -100,6 +100,9 @@ func (e *VariableEWMA) Add(value float64) {
 	} else if e.count == WARMUP_SAMPLES {
 		e.value = e.value / float64(WARMUP_SAMPLES)
 		e.count++
+		//You lost slice[WARMUP_SAMPLES] item
+		//just compute samples := [12]float64{0,1,2,3,4,5,6,7,8,9,10000,11}
+		e.value = (value * e.decay) + (e.value * (1 - e.decay))
 	} else {
 		e.value = (value * e.decay) + (e.value * (1 - e.decay))
 	}


### PR DESCRIPTION
原程序丢失了计算序列中的slice[WARMUP_SAMPLES]项。

package main

import (
	"fmt"

	"github.com/VividCortex/ewma"
)

func main() {
	samples := [12]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10000, 11}

	e := ewma.NewMovingAverage()  //=> Returns a SimpleEWMA if called without params
	a := ewma.NewMovingAverage(5) //=> returns a VariableEWMA with a decay of 2 / (5 + 1)

	for _, f := range samples {
		e.Add(f)
		a.Add(f)
	}

	fmt.Println(e.Value())   //606.8771523549624
	fmt.Println(a.Value())   //6.666666666666667
}