### PR TITLE
 ValueIgnoreWarmup - helpful for debugging

### DIFF
--- a/ewma.go
+++ b/ewma.go
@@ -117,6 +117,11 @@ func (e *VariableEWMA) Value() float64 {
 	return e.value
 }
 
+// Value returns the current value of the average. It ignores the warmup safeguard
+//handy for testing or debugging.
+func (e *VariableEWMA) ValueIgnoreWarmup() float64 {
+	return e.value
+}
 // Set sets the EWMA's value.
 func (e *VariableEWMA) Set(value float64) {
 	e.value = value

--- a/ewma.go
+++ b/ewma.go
@@ -28,6 +28,7 @@ const (
 type MovingAverage interface {
 	Add(float64)
 	Value() float64
+	ValueIgnoreWarmup() float64
 	Set(float64)
 }
 
@@ -73,6 +74,12 @@ func (e *SimpleEWMA) Add(value float64) {
 
 // Value returns the current value of the moving average.
 func (e *SimpleEWMA) Value() float64 {
+	return e.value
+}
+
+// Value returns the current value of the average. It ignores the warmup safeguard
+//handy for testing or debugging.
+func (e *SimpleEWMA) ValueIgnoreWarmup() float64 {
 	return e.value
 }
 


### PR DESCRIPTION
 Value returns the current value of the average. It ignores the warmup safeguard
handy for testing or debugging.