### PR TITLE
Fix wrong format type in Errorf

### DIFF
--- a/ewma_test.go
+++ b/ewma_test.go
@@ -36,7 +36,7 @@ func TestSimpleEWMA(t *testing.T) {
 	}
 	e.Set(1.0)
 	if e.Value() != 1.0 {
-		t.Errorf("e.Value() is %d", e.Value())
+		t.Errorf("e.Value() is %v", e.Value())
 	}
 }
 
@@ -50,7 +50,7 @@ func TestVariableEWMA(t *testing.T) {
 	}
 	e.Set(1.0)
 	if e.Value() != 1.0 {
-		t.Errorf("e.Value() is %d", e.Value())
+		t.Errorf("e.Value() is %v", e.Value())
 	}
 }
 
@@ -80,7 +80,7 @@ func TestVariableEWMAWarmup(t *testing.T) {
 	e.Set(5)
 	e.Add(1)
 	if e.Value() >= 5 {
-		t.Errorf("e.Value() is %d, expected it to decay towards 0", e.Value())
+		t.Errorf("e.Value() is %v, expected it to decay towards 0", e.Value())
 	}
 }
 


### PR DESCRIPTION
I'm encountering new errors with Golang 1.10.rc2:

```
+ go test -buildmode pie -compiler gc -ldflags ' -extldflags '\''-Wl,-z,relro  -specs=/usr/lib/rpm/redhat/redhat-hardened-ld '\''' github.com/VividCortex/ewma
# github.com/VividCortex/ewma
../../BUILDROOT/golang-github-VividCortex-ewma-1.1.1-2.fc28.x86_64/usr/share/gocode/src/github.com/VividCortex/ewma/ewma_test.go:39: Errorf format %d has arg e.Value() of wrong type float64
../../BUILDROOT/golang-github-VividCortex-ewma-1.1.1-2.fc28.x86_64/usr/share/gocode/src/github.com/VividCortex/ewma/ewma_test.go:53: Errorf format %d has arg e.Value() of wrong type float64
../../BUILDROOT/golang-github-VividCortex-ewma-1.1.1-2.fc28.x86_64/usr/share/gocode/src/github.com/VividCortex/ewma/ewma_test.go:83: Errorf format %d has arg e.Value() of wrong type float64
FAIL	github.com/VividCortex/ewma [build failed]
```

It seems the Errorf statement is expecting an integer number with %d, but in all case a float64 is provided. I propose to use %v instead.